### PR TITLE
Ajuste padding del menu desplegable

### DIFF
--- a/assets/style/responsivehome.css
+++ b/assets/style/responsivehome.css
@@ -26,7 +26,7 @@
         align-items: flex-start;
     }
     .menu-activo li {
-        margin: 20px 60px;
+        margin: 20px 0px 20px 50px;
     }
     .menu-activo li a {
         color: #30475e;


### PR DESCRIPTION
Ajusto el padding izquierdo y derecho del elemento "li", en el menu desplegable.
Esto corrigue un bug que consistía en que las letras de los liks se amontonaban cuando el viewport es muy pequeño.